### PR TITLE
Remove script.js link in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,5 @@
             <button id="dark-theme">Dark</button>
         </div>
     </div>
-    <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Fix for:

📍 **Location**: Go to “**Step 1: Adding JavaScript to the web page”** and then to the  step under the second “Your Turn” that reads “Create a new JavaScript file named `script.js` and link it to your HTML page.”

🐞Problem: The step tells students to link the JavaScript file `script.js`, but the file already linked in the HTML. Update the starter code.

See Ticket: https://www.notion.so/deliveryteam/Unit-2-Lab-2-Step-1-f37171d6469c4d5a8e8f84063c930a7d?pvs=4 